### PR TITLE
Add play/pause functionality to Snake game

### DIFF
--- a/snake.h
+++ b/snake.h
@@ -13,7 +13,7 @@ using std::chrono::system_clock;
 using namespace std::this_thread;
 
 char direction='r';
-
+bool paused = false;
 void input_handler(){
     // change terminal settings
     struct termios oldt, newt;
@@ -22,15 +22,23 @@ void input_handler(){
     // turn off canonical mode and echo
     newt.c_lflag &= ~(ICANON | ECHO);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-    map<char, char> keymap = {{'d', 'r'}, {'a', 'l'}, {'w', 'u'}, {'s', 'd'}, {'q', 'q'}};
-    while (true) {
-        char input = getchar();
-        if (keymap.find(input) != keymap.end()) {
-            direction = keymap[input];
-        } else if (input == 'q'){
-            exit(0);
-        }
+   map<char, char> keymap = {
+    {'d', 'r'}, {'a', 'l'}, {'w', 'u'}, {'s', 'd'}, {'q', 'q'}
+};
+while (true) {
+    char input = getchar();
+
+    if (input == 'p') {
+        paused = !paused;  // toggle pause on/off
     }
+    else if (keymap.find(input) != keymap.end()) {
+        direction = keymap[input];
+    } 
+    else if (input == 'q') {
+        exit(0);
+    }
+}
+
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
 }
 
@@ -80,6 +88,13 @@ void game_play() {
     for (pair<int, int> head = make_pair(0, 1); ; head = get_next_head(head, direction)) {
         cout << "\033[H";
 
+        while (paused) {
+            cout << "\033[H"; // reset cursor
+            render_game(10, snake, food, poison);
+            cout << "\n==== PAUSED ====" << endl;
+            cout << "Press 'p' to resume..." << endl;
+            sleep_for(chrono::milliseconds(200));
+        }
         // check self collision
         if (find(snake.begin(), snake.end(), head) != snake.end()) {
             system("clear");


### PR DESCRIPTION
Add play/pause functionality to the Snake game : 
- Introduced a global 'paused' flag to track game state
- Updated input_handler() to toggle pause with 'p' key
- Pauses the game loop when paused and displays a message
- Keeps the board visible while paused
- Other game logic remains unchanged

Issue Reference
Fixes #5 